### PR TITLE
Create seachable PDF with tesseract

### DIFF
--- a/GoBooDo.py
+++ b/GoBooDo.py
@@ -147,7 +147,10 @@ class  GoBooDo:
         downloadService.getImages(settings['max_retry_images']+1)
         print('------------------- Creating PDF -------------------')
         service = createBook(self.name, self.path)
-        service.makePdf()
+        if (settings.get('lang')):
+            service.ocrPdf(lang=settings['lang'])
+        else:
+            service.makePdf()
 
     def start(self):
         try:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The configuration can be done in the settings.json and the description is as fol
   "proxy_links":0,   // 0 for disabling proxy when fetching page links upon reaching the limit.
   "proxy_images":0,  // 0 for disabling proxy when fetching  page images upon reaching the limit.
   "max_retry_links":1, // Max retries for fetching a link using proxies.
-  "max_retry_images":1 // Max retries for a fetching a image using proxies.
-  "global_retry_time": // 0 for not running GoBooDo indefinitely, the number of seconds of delay between each global retry otherwise.
+  "max_retry_images":1, // Max retries for a fetching a image using proxies.
+  "global_retry_time":30, // 0 for not running GoBooDo indefinitely, the number of seconds of delay between each global retry otherwise.
+  "lang": "" // "" for create PDF without OCR, languages which OCR reads in. E.g. "eng+ita".
 }
 ~~~
 
@@ -63,7 +64,10 @@ fpdf
 html5lib
 tqdm
 pytesseract
+pypdf2
 ~~~
+
+If you want to use OCR with languages other than English, you should download aditional languages data from [tesseract-ocr](https://github.com/tesseract-ocr).
 
 # Features 
 1. Stateful : GoBooDo keeps a track of the books which are downloaded. In each subsequent iterations of operation only those those links and images are fetched which were not downloaded earlier.

--- a/makePDF.py
+++ b/makePDF.py
@@ -2,6 +2,9 @@ from fpdf import FPDF
 import os
 from PIL import Image
 from tqdm import tqdm
+from pytesseract import image_to_pdf_or_hocr
+import PyPDF2
+from io import BytesIO
 
 class createBook:
 
@@ -23,3 +26,17 @@ class createBook:
         name = str(self.name[:min(10,len(self.name))]).replace(" ","")
         name = ''.join(ch for ch in name if ch.isalnum()) + ".pdf"
         pdf.output(os.path.join(self.path,'Output',name),"F")
+
+    def ocrPdf(self, lang=None):
+        pdf = PyPDF2.PdfFileWriter()
+        for pagePath in tqdm(self.imageNameList):
+            with open(pagePath, 'rb') as ofile:
+                im = Image.open(ofile)
+                page = image_to_pdf_or_hocr(im, lang=lang)
+            pdf.addPage(PyPDF2.PdfFileReader(BytesIO(page)).getPage(0))
+        if not os.path.exists(os.path.join(self.path,'Output')):
+            os.mkdir(os.path.join(self.path,'Output'))
+        name = str(self.name[:min(10,len(self.name))]).replace(" ","")
+        name = ''.join(ch for ch in name if ch.isalnum()) + ".pdf"
+        with open(os.path.join(self.path,'Output',name),'wb') as ofile:
+            pdf.write(ofile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ fpdf
 html5lib
 tqdm
 pytesseract
+pypdf2

--- a/settings.json
+++ b/settings.json
@@ -6,5 +6,6 @@
     "proxy_images": 0,
     "max_retry_links": 1,
     "max_retry_images": 1,
-    "global_retry_time": 30
+    "global_retry_time": 30,
+    "lang": ""
 }


### PR DESCRIPTION
This pull request makes GoBooDo to make a searchable PDF with OCR. See also: #58.

# How does this work

Tesseractor makes searchable PDFs from images and merge PDFs by PyPDF2.

# Usage

If `lang` is not in `settings.json` or empty, GoBooDo create unsearchable PDF (same as now).

If not empty, GoBooDo create searchable PDF. GoBooDo do OCR as the book is written in item of `lang`.

# Note

This pull requests increase dependence (PyPDF2). So if user update GoBooDo and haven't installed PyPDF2, no modules error will occur in `makePDF.py`.

It takes time to OCR and it is waste of time and electricity to do OCR even though GoBooDo hasn't finished downloading all images (#59).

If user want to do OCR with languages other than English, he or she should install [additional language data](https://github.com/tesseract-ocr/tessdata). And there are other language datas [for more accurate OCR (but slow)](https://github.com/tesseract-ocr/tessdata_best) or [for faster](https://github.com/tesseract-ocr/tessdata_fast).